### PR TITLE
Shadow copy optimize and source destination checks

### DIFF
--- a/ntfs-hardlink-backup.ps1
+++ b/ntfs-hardlink-backup.ps1
@@ -130,7 +130,11 @@ if (($backupDestinationArray[0] -eq "") -and ($backupDestinationArray[1] -eq "")
 	# The destination is a UNC path (file share)
 	$backupDestinationTop = "\\" + $backupDestinationArray[2] + "\" + $backupDestinationArray[3] + "\"
 } else {
-	# Hopefully the destination is on an ordinary drive letter
+	if (-not ($backupDestination -match ":")) {
+		# No drive letter specified. This could be an attempt at a relative path, so first resolve it to the full path.
+		# This allows us to use split-path -Qualifier below to get the actual drive letter
+		$backupDestination = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($backupDestination)
+	}
 	$backupDestinationTop = split-path $backupDestination -Qualifier
 	$backupDestinationTop = $backupDestinationTop + "\"
 }
@@ -146,7 +150,11 @@ if (test-path $backupDestinationTop) {
 				# The source is a UNC path (file share) which has no drive letter. We cannot do volume shadowing from that.
 				$backup_source_drive_letter = ""
 			} else {
-				# Hopefully the source is on an ordinary drive letter
+				if (-not ($backup_source -match ":")) {
+					# No drive letter specified. This could be an attempt at a relative path, so first resolve it to the full path.
+					# This allows us to use split-path -Qualifier below to get the actual drive letter
+					$backup_source = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($backup_source)
+				}
 				$backup_source_drive_letter = split-path $backup_source -Qualifier
 				$backup_source_path =  split-path $backup_source -noQualifier
 			}


### PR DESCRIPTION
Handle case where source is a UNC path, and/or destination is a UNC path. Now it will backup from source UNC path to destination UNC path. (or any combination of UNC or drive letter in source and destination)
Check that source path exists and backup destination drive or \server\share exists. Log error if not, rather than bothering to run "ln" at all.
Optimize use of shadow copy - if the same drive letter repeats in the source list then keep using the same shadow copy.
Minor text and white space cleanup.
The diff listing looks horrible because large blocks of code were tabbed in.
