### PR TITLE
Allow Delorean backup to work with hidden folders

### DIFF
--- a/ntfs-hardlink-backup.ps1
+++ b/ntfs-hardlink-backup.ps1
@@ -365,11 +365,11 @@ if (($doBackup -eq $True) -and (test-path $backupDestinationTop)) {
 			$lastBackupFolderName = ""
 			$lastBackupFolders = @()
 			If (Test-Path $backupDestination){
-				$oldBackupItems = Get-ChildItem -Path $backupDestination
+				$oldBackupItems = Get-ChildItem -Force -Path $backupDestination
 				# get me the last backup if any
 				foreach ($item in $oldBackupItems)
 				{
-					if ($item.Attributes -eq "Directory" -AND $item.Name  -match '^'+$backup_source_folder+' - \d{4}-\d{2}-\d{2} \d{2}-\d{2}-\d{2}$' )
+					if ($item.Attributes -match "Directory" -AND $item.Name  -match '^'+$backup_source_folder+' - \d{4}-\d{2}-\d{2} \d{2}-\d{2}-\d{2}$' )
 					{
 						$lastBackupFolderName = $item.Name
 						$lastBackupFolders += $item


### PR DESCRIPTION
If the input folder for the backup is a hidden folder (like we are hiding D:\Tmail from the user) then the output backup on "X:\Backup\Tmail - datetime" is also a hidden file.
When looking for previous backups in backup destination like X:\Backup, we need to force Get-ChildItem to return all files, and then to see if it is a directory, the attributes just need to contain (-match) "Directory". For a hidden directory, Attributes returns "Hidden, Directory".
