### PR TITLE
Add emailJobName option

### DIFF
--- a/ntfs-hardlink-backup.ps1
+++ b/ntfs-hardlink-backup.ps1
@@ -49,8 +49,10 @@
     Switch off the use of Shadow Copies. Can be useful if you have no permissions to create Shadow Copies.
 .PARAMETER SMTPPort
     Port of the SMTP Server. Default=587
+.PARAMETER emailJobName
+    This is added in to the auto-generated email subject "Backup of: hostname emailJobName by: username"
 .PARAMETER emailSubject
-    Subject for the notification Email.
+    Subject for the notification Email. This overrides the auto-generated email subject and emailJobName.
 .PARAMETER emailSendRetries
     How often should we try to resend the Email. Default = 100
 .PARAMETER msToPauseBetweenEmailSendRetries
@@ -109,6 +111,8 @@ Param(
    [Parameter(Mandatory=$False)]
    [string]$emailSubject="",
    [Parameter(Mandatory=$False)]
+   [string]$emailJobName="",
+   [Parameter(Mandatory=$False)]
    [String[]]$exclude,
    [Parameter(Mandatory=$False)]
    [string]$LogFile="",
@@ -128,7 +132,10 @@ $backupMappedPath = ""
 $backupHostName = ""
 
 if ([string]::IsNullOrEmpty($emailSubject)) {
-	$emailSubject = "Backup of: {0} by: {1}" -f $(Get-WmiObject Win32_Computersystem).name, [Environment]::UserName
+	if (-not ([string]::IsNullOrEmpty($emailJobName))) {
+		$emailJobName += " "
+	}
+	$emailSubject = "Backup of: {0} ${emailJobName}by: {1}" -f $(Get-WmiObject Win32_Computersystem).name, [Environment]::UserName
 }
 
 $script_path = Split-Path -parent $MyInvocation.MyCommand.Definition
@@ -430,7 +437,7 @@ if (($doBackup -eq $True) -and (test-path $backupDestinationTop)) {
 
 			echo "done`n"
 
-			$summary = "`n------Summary-----`nBackup AT: $start_time FROM: $backup_source TO: $backupDestination`n" + $summary
+			$summary = "`n------Summary-----`nBackup AT: $start_time FROM: $backup_source TO: $backupDestination $backupMappedPath`n" + $summary
 			echo $summary
 
 			$emailBody = $emailBody + $summary


### PR DESCRIPTION
This allows the user to specify a little bit of text that goes in the email subject, along with the hostname and username. This is handy when there are multiple different backups for different purposes on the same host. It makes it easy to distinguish the different backup emails by email subject. e.g.
-emailJobName 'to NAS'
The email subject becomes something like:
Backup of: OFFICE-DC-01 to NAS by: backup.account

Also added output of backupMappedPath to the email body summary. That helps when drive X:\ is actually mapped to some file share \office-nas.company.com\backup - then the user can see in the email body where the backup destination drive letter was actually mapped to.
