### PR TITLE
Features and fixes for rc8

### DIFF
--- a/ntfs-hardlink-backup.ps1
+++ b/ntfs-hardlink-backup.ps1
@@ -479,27 +479,30 @@ if (($doBackup -eq $True) -and (test-path $backupDestinationTop)) {
 			}
 			#plus 1 because we just created a new backup
 			$backupsToDelete=$lastBackupFolders.length + 1 - $backupsToKeep
-			echo  "$stepCounter. $stepTime Deleting $backupsToDelete old backup(s) ..."
-			$stepCounter++
-			if ($LogFile) {
-				"`r`nDeleting $backupsToDelete old backup(s)" | Out-File $LogFile  -encoding ASCII -append
-			}
-			$backupsDeleted = 0
-			while ($backupsDeleted -lt $backupsToDelete)
+			if ($backupsToDelete -gt 0)
 			{
-				$folderToDelete =  $backupDestination +"\"+ $lastBackupFolders[$backupsDeleted].Name
-				echo "Deleting $folderToDelete"
+				echo  "$stepCounter. $stepTime Deleting $backupsToDelete old backup(s) ..."
+				$stepCounter++
 				if ($LogFile) {
-					"`r`nDeleting $folderToDelete" | Out-File $LogFile  -encoding ASCII -append
+					"`r`nDeleting $backupsToDelete old backup(s)" | Out-File $LogFile  -encoding ASCII -append
 				}
-				$backupsDeleted++
-				`cmd /c  "$script_path\..\ln.exe --deeppathdelete `"$folderToDelete`" $logFileCommandAppend"`
-			}
+				$backupsDeleted = 0
+				while ($backupsDeleted -lt $backupsToDelete)
+				{
+					$folderToDelete =  $backupDestination +"\"+ $lastBackupFolders[$backupsDeleted].Name
+					echo "Deleting $folderToDelete"
+					if ($LogFile) {
+						"`r`nDeleting $folderToDelete" | Out-File $LogFile  -encoding ASCII -append
+					}
+					$backupsDeleted++
+					`cmd /c  "$script_path\..\ln.exe --deeppathdelete `"$folderToDelete`" $logFileCommandAppend"`
+				}
 
-			$summary = "`nDeleted $backupsDeleted old backup(s)`n"
-			echo $summary
-			if ($LogFile) {
-				$summary | Out-File $LogFile  -encoding ASCII -append
+				$summary = "`nDeleted $backupsDeleted old backup(s)`n"
+				echo $summary
+				if ($LogFile) {
+					$summary | Out-File $LogFile  -encoding ASCII -append
+				}
 			}
 
 			$emailBody = $emailBody + $summary


### PR DESCRIPTION
1) Bug fix - the list of old backups was not explicitly sorted, and it turned out that the newest "previous backup" was being deleted rather than the oldest.
2) When deleting old backups, they did not always get deleted because Remove-Item was respecting read-only files. Could have fixed that by adding the -Force option. But also Remove-Item fails on files with total path names exceeding the "about 260" character limit. So Remove-Item is replaced by running ln -deeppathdelete - that seems to really delete stuff.
3) Enhancement - support the --noads and --noea args that ln supports, so they can be passed through if needed.
4) timetolerance arg is now applied to full copy, as well as Delorian copy.
