### PR TITLE
RC9 enhancements and fixes

### DIFF
--- a/ntfs-hardlink-backup.ps1
+++ b/ntfs-hardlink-backup.ps1
@@ -656,16 +656,17 @@ if (($doBackup -eq $True) -and (test-path $backupDestinationTop)) {
 	}
 
 } else {
+	if ($backupMappedPath) {
+		$backupMappedString = " (" + $backupMappedPath + ")"
+	} else {
+		$backupMappedString = ""
+	}
+
 	if ($doBackup -eq $True) {
 		# The destination drive or \\server\share does not exist.
-		$output = "ERROR: Destination drive or share does not exist - backup NOT done`r`n"
+		$output = "ERROR: Destination drive or share $backupDestinationTop$backupMappedString does not exist - backup NOT done`r`n"
 	} else {
 		# The backup was not done because localSubnetOnly was on, and the destination \\server\share is not in the local subnet.
-		if ($backupMappedPath -ne "") {
-			$backupMappedString = " (" + $backupMappedPath + ")"
-		} else {
-			$backupMappedString = ""
-		}
 		$output = "ERROR: Destination share $backupDestinationTop$backupMappedString is not in a local subnet - backup NOT done`r`n"
 	}
 	$emailBody = "$emailBody`r`n$output`r`n"


### PR DESCRIPTION
1) Various white space and minor text updates
2) Add localSubnetMask - this allows the user to tell us how wide a range of IP addresses are considered local to the network backup device. Use it if you have a number of subnets at an office that are high-speed and you are happy to backup to file shares across those subnets. It relies on the network design being such that the subnets at an office can be summarised into 1 large subnet/CIRD mask.
3) If a log file is not specified, then generate a date-time-stamp.log file name in the backup destination. If just a folder is specified, then generate a date-time-stamp.log file name in the specified folder. Otherwise do like before, write/append to the specified log file.
4) Handle finding old backups so that it finds even old backup folders that are hidden.
5) Delete old log files also - keeping the same number as backups to keep.
