### PR TITLE
If path to ln.exe path have spaces, we get an error when running the script.

### DIFF
--- a/ntfs-hardlink-backup/ntfs-hardlink-backup.ps1
+++ b/ntfs-hardlink-backup/ntfs-hardlink-backup.ps1
@@ -807,7 +807,7 @@ if ([string]::IsNullOrEmpty($lnPath) -or !(Test-Path -Path $lnPath -PathType lea
 	}
 }
 #try to run ln.exe just to check if it can start. Possible that the ln version does not fit the Windows version (e.g. 64bit installed on a 32bit system)
-$output=`cmd /c "$lnPath -h" 2`>`&1`
+$output=`cmd /c "`"$lnPath`"  -h" 2`>`&1`
 
 #if we could not find ln.exe, there is no point in trying to make a backup
 if ([string]::IsNullOrEmpty($lnPath) -or !(Test-Path -Path $lnPath -PathType leaf) -or ($LASTEXITCODE -ne 0) ) {
@@ -1339,7 +1339,7 @@ if (($parameters_ok -eq $True) -and ($doBackup -eq $True) -and (test-path $backu
 				}
 
 				#echo "$lnPath $commonArgumentString --copy `"$backup_source_path`" `"$actualBackupDestination`"    $logFileCommandAppend"
-				`cmd /c  "$lnPath $commonArgumentString --copy `"$backup_source_path`" `"$actualBackupDestination`" $logFileCommandAppend 2`>`&1 "`
+				`cmd /c  "`"`"$lnPath`" $commonArgumentString --copy `"$backup_source_path`" `"$actualBackupDestination`" $logFileCommandAppend 2`>`&1 `""`
 			} else {
 				echo "Delorian copy from $backup_source_path to $actualBackupDestination$backupMappedString against $selectedBackupDestination\$lastBackupFolderName"
 				if ($LogFile) {
@@ -1347,7 +1347,7 @@ if (($parameters_ok -eq $True) -and ($doBackup -eq $True) -and (test-path $backu
 				}
 
 				#echo "$lnPath $commonArgumentString --delorean `"$backup_source_path`" `"$selectedBackupDestination\$lastBackupFolderName`" `"$actualBackupDestination`" $logFileCommandAppend"
-				`cmd /c  "$lnPath $commonArgumentString --delorean `"$backup_source_path`" `"$selectedBackupDestination\$lastBackupFolderName`" `"$actualBackupDestination`" $logFileCommandAppend 2`>`&1 "`
+				`cmd /c  "`"`"$lnPath`" $commonArgumentString --delorean `"$backup_source_path`" `"$selectedBackupDestination\$lastBackupFolderName`" `"$actualBackupDestination`" $logFileCommandAppend 2`>`&1 `""`
 			}
 			
 			$saved_lastexitcode = $LASTEXITCODE
@@ -1427,7 +1427,7 @@ if (($parameters_ok -eq $True) -and ($doBackup -eq $True) -and (test-path $backu
 					}
 					$backupsDeleted++
 
-					`cmd /c  "$lnPath --deeppathdelete `"$folderToDelete`" $logFileCommandAppend"`
+					`cmd /c  "`"`"$lnPath`"  --deeppathdelete `"$folderToDelete`" $logFileCommandAppend`""`
 				}
 
 				$summary = "`nDeleted $backupsDeleted old backup(s)`n"


### PR DESCRIPTION
Fixed by adding double quotes around $lnPath and around full cmd line argument.

As cmd help says: (http://ss64.com/nt/syntax-cmd.html)

**Quote Characters in a command**
If /C or /K is specified, then the remainder of the command line is interpreted as a command and the following logic is used to process quote (") characters:

1. If all of the following conditions are met, then quote characters on the command line are preserved:

- No /S switch (Strip quotes) 
- Exactly two quote characters
- No special characters between the two quote characters, where special is one of: & < >( ) @ ^ |
- There are one or more whitespace characters between the the two quote characters
- The string between the two quote characters is the name of an executable file.

2. Otherwise, old behavior is to see if the first character is a quote character and if so, strip the leading character and remove the last quote character on the command line, preserving any text after the last quote character. To negate this behaviour use a double set of quotes "" at the start and end of the command line.

`CMD /c ""c:\work\my reports\profit ^& Loss.doc""`