### PR TITLE
Generate XML status report of the last hardlink backup run

### DIFF
--- a/ntfs-hardlink-backup/ntfs-hardlink-backup.ps1
+++ b/ntfs-hardlink-backup/ntfs-hardlink-backup.ps1
@@ -798,12 +798,14 @@ if ([string]::IsNullOrEmpty($emailSubject)) {
 
 if ([string]::IsNullOrEmpty($emailJobName)) {
 	$emailJobName = Get-IniParameter "emailJobName" "${FQDN}"
-	
+}
+
+if (-not [string]::IsNullOrEmpty($emailJobName)) {
 	$output = "`WARNING: using the 'emailJobName' parameter is deprecated! Please use 'jobName'`n"
 	echo $output
 	$emailBody = "$emailBody`r`n$output`r`n"
 
-	$tempLogContent += $output	
+	$tempLogContent += $output
 }
 
 if ([string]::IsNullOrEmpty($jobName)) {

--- a/ntfs-hardlink-backup/ntfs-hardlink-backup.ps1
+++ b/ntfs-hardlink-backup/ntfs-hardlink-backup.ps1
@@ -1768,6 +1768,35 @@ if (($parameters_ok -eq $True) -and ($doBackup -eq $True) -and (test-path $backu
 	}
 }
 
+#XML Status report
+echo "============Generating XML Status report============"
+
+$XMLStatusFile = "$logFileDestination\status.xml"
+$XmlWriter = New-Object System.XMl.XmlTextWriter($XMLStatusFile,$Null)
+$xmlWriter.Formatting = 'Indented'
+$xmlWriter.Indentation = 1
+$XmlWriter.IndentChar = "`t"
+
+$xmlWriter.WriteStartDocument()
+
+if ($error_during_backup) {
+	$XMLStatus = "ERROR"
+} else {
+	$XMLStatus = "OK"
+}
+
+$xmlWriter.WriteStartElement('NTFS-HARDLINK-BACKUP')
+$XmlWriter.WriteElementString('VERSION', $versionString)
+$XmlWriter.WriteElementString('STATUS', $XMLStatus)
+$XmlWriter.WriteElementString('JOBNAME', $emailJobName.Trim())
+$XmlWriter.WriteElementString('LASTRUN', $dateTime)
+$XmlWriter.WriteElementString('DESTINATION', "$selectedBackupDestination$backupMappedString")
+
+$xmlWriter.WriteEndElement()
+$xmlWriter.WriteEndDocument()
+$xmlWriter.Flush()
+$xmlWriter.Close()
+
 if ($emailTo -AND $emailFrom -AND $SMTPServer) {
 	# Check if we can find any network adapter that has a default gateway
 	$localAdapters = (Get-WmiObject -Class Win32_NetworkAdapterConfiguration -Filter 'ipenabled = "true"')

--- a/ntfs-hardlink-backup/ntfs-hardlink-backup.ps1
+++ b/ntfs-hardlink-backup/ntfs-hardlink-backup.ps1
@@ -1832,7 +1832,7 @@ if ($error_during_backup) {
 $dateTimeforXML = [DateTime]::ParseExact($dateTime, "yyyy-MM-dd HH-mm-ss", $null)
 $dateTimeforXML = Get-Date -Date $dateTimeforXML -f "yyyy-MM-dd HH:mm:ss"
 
-$xmlWriter.WriteStartElement('NTFS-HARDLINK-BACKUP')
+$xmlWriter.WriteStartElement('NTFSHARDLINKBACKUP')
 $xmlWriter.WriteElementString('VERSION', $versionString)
 $xmlWriter.WriteElementString('STATUS', $backupStatus)
 $xmlWriter.WriteElementString('JOBNAME', $jobName)

--- a/ntfs-hardlink-backup/ntfs-hardlink-backup.ps1
+++ b/ntfs-hardlink-backup/ntfs-hardlink-backup.ps1
@@ -1814,25 +1814,25 @@ if (($parameters_ok -eq $True) -and ($doBackup -eq $True) -and (test-path $backu
 
 #XML Status report
 echo "============Generating XML Status report============"
-$XmlWriter = New-Object System.XMl.XmlTextWriter($statusFile,$Null)
+$xmlWriter = New-Object System.XMl.XmlTextWriter($statusFile,$Null)
 $xmlWriter.Formatting = 'Indented'
 $xmlWriter.Indentation = 1
-$XmlWriter.IndentChar = "`t"
+$xmlWriter.IndentChar = "`t"
 
 $xmlWriter.WriteStartDocument()
 
 if ($error_during_backup) {
-	$XMLStatus = "ERROR"
+	$backupStatus = "ERROR"
 } else {
-	$XMLStatus = "OK"
+	$backupStatus = "OK"
 }
 
 $xmlWriter.WriteStartElement('NTFS-HARDLINK-BACKUP')
-$XmlWriter.WriteElementString('VERSION', $versionString)
-$XmlWriter.WriteElementString('STATUS', $XMLStatus)
-$XmlWriter.WriteElementString('JOBNAME', $jobName)
-$XmlWriter.WriteElementString('LASTRUN', $dateTime)
-$XmlWriter.WriteElementString('DESTINATION', "$selectedBackupDestination$backupMappedString")
+$xmlWriter.WriteElementString('VERSION', $versionString)
+$xmlWriter.WriteElementString('STATUS', $backupStatus)
+$xmlWriter.WriteElementString('JOBNAME', $jobName)
+$xmlWriter.WriteElementString('LASTRUN', $dateTime)
+$xmlWriter.WriteElementString('DESTINATION', "$selectedBackupDestination$backupMappedString")
 
 $xmlWriter.WriteEndElement()
 $xmlWriter.WriteEndDocument()

--- a/ntfs-hardlink-backup/ntfs-hardlink-backup.ps1
+++ b/ntfs-hardlink-backup/ntfs-hardlink-backup.ps1
@@ -1827,11 +1827,16 @@ if ($error_during_backup) {
 	$backupStatus = "OK"
 }
 
+#make the DateTime more general/SQL like. We have used "-" between h,m & m because we cannot have ":" in the folder/filenames
+#but here we really want to have something that is more general and easier to parse
+$dateTimeforXML = [DateTime]::ParseExact($dateTime, "yyyy-MM-dd HH-mm-ss", $null)
+$dateTimeforXML = Get-Date -Date $dateTimeforXML -f "yyyy-MM-dd HH:mm:ss"
+
 $xmlWriter.WriteStartElement('NTFS-HARDLINK-BACKUP')
 $xmlWriter.WriteElementString('VERSION', $versionString)
 $xmlWriter.WriteElementString('STATUS', $backupStatus)
 $xmlWriter.WriteElementString('JOBNAME', $jobName)
-$xmlWriter.WriteElementString('LASTRUN', $dateTime)
+$xmlWriter.WriteElementString('LASTRUN', $dateTimeforXML)
 $xmlWriter.WriteElementString('DESTINATION', "$selectedBackupDestination$backupMappedString")
 
 $xmlWriter.WriteEndElement()

--- a/ntfs-hardlink-backup/ntfs-hardlink-backup.ps1
+++ b/ntfs-hardlink-backup/ntfs-hardlink-backup.ps1
@@ -87,7 +87,7 @@
 	Port of the SMTP Server. Default=587
 .PARAMETER jobName
 	This is added in to the auto-generated email subject "Backup of: hostname jobName by: username" and used in the status file.
-	Using the 'emailJobName' parameter is depreciated
+	Using the 'emailJobName' parameter is deprecated
 .PARAMETER emailSubject
 	Subject for the notification Email. This overrides the auto-generated email subject and jobName.
 .PARAMETER emailSendRetries
@@ -799,7 +799,7 @@ if ([string]::IsNullOrEmpty($emailSubject)) {
 if ([string]::IsNullOrEmpty($emailJobName)) {
 	$emailJobName = Get-IniParameter "emailJobName" "${FQDN}"
 	
-	$output = "`WARNING: using the 'emailJobName' parameter is depreciated! Please use 'jobName'`n"
+	$output = "`WARNING: using the 'emailJobName' parameter is deprecated! Please use 'jobName'`n"
 	echo $output
 	$emailBody = "$emailBody`r`n$output`r`n"
 
@@ -809,7 +809,7 @@ if ([string]::IsNullOrEmpty($emailJobName)) {
 if ([string]::IsNullOrEmpty($jobName)) {
 	$jobName = Get-IniParameter "jobName" "${FQDN}"
 	
-	#if there is still not $jobName set use the depreciated $emailJobName
+	#if there is still not $jobName set use the deprecated $emailJobName
 	if ([string]::IsNullOrEmpty($jobName)) {
 		$jobName=$emailJobName
 	}


### PR DESCRIPTION
added a function that generates a status report of the last backup run.
This can be used to determine the backup status of the computer (for inventory system, display a message to the user, notify the administrator)

@phil-davis please review. 
Should we use a new parameter instead of $emailJobName. "emailJobName" might be confusing as its not used not only for emails.