### PR TITLE
Generate XML status report of the last Robocopy run

### DIFF
--- a/robocopy-backup/robocopy-backup-to-disk.ini
+++ b/robocopy-backup/robocopy-backup-to-disk.ini
@@ -6,6 +6,7 @@ backupDestination=E:\BackupTest
 logFilesToKeep=5
 noshadowcopy=true
 Logfile=C:\Logs\Robocopy-Backup-To-External-HDD
+statusFile=robocopy-status.xml
 SMTPServer=mail.mycompany.com
 SMTPUser=backup@mycompany.com
 SMTPPassword=blahblah

--- a/robocopy-backup/robocopy-backup.ps1
+++ b/robocopy-backup/robocopy-backup.ps1
@@ -714,12 +714,14 @@ if ([string]::IsNullOrEmpty($emailSubject)) {
 
 if ([string]::IsNullOrEmpty($emailJobName)) {
 	$emailJobName = Get-IniParameter "emailJobName" "${FQDN}"
-	
+}
+
+if (-not [string]::IsNullOrEmpty($emailJobName)) {
 	$output = "`WARNING: using the 'emailJobName' parameter is deprecated! Please use 'jobName'`n"
 	echo $output
 	$emailBody = "$emailBody`r`n$output`r`n"
 
-	$tempLogContent += $output	
+	$tempLogContent += $output
 }
 
 if ([string]::IsNullOrEmpty($jobName)) {
@@ -1511,11 +1513,16 @@ if ($error_during_backup) {
 	$backupStatus = "OK"
 }
 
-$xmlWriter.WriteStartElement('ROBOCOPY-BACKUP')
+#make the DateTime more general/SQL like. We have used "-" between h,m & m because we cannot have ":" in the folder/filenames
+#but here we really want to have something that is more general and easier to parse
+$dateTimeforXML = [DateTime]::ParseExact($dateTime, "yyyy-MM-dd HH-mm-ss", $null)
+$dateTimeforXML = Get-Date -Date $dateTimeforXML -f "yyyy-MM-dd HH:mm:ss"
+
+$xmlWriter.WriteStartElement('ROBOCOPYBACKUP')
 $xmlWriter.WriteElementString('VERSION', $versionString)
 $xmlWriter.WriteElementString('STATUS', $backupStatus)
 $xmlWriter.WriteElementString('JOBNAME', $jobName)
-$xmlWriter.WriteElementString('LASTRUN', $dateTime)
+$xmlWriter.WriteElementString('LASTRUN', $dateTimeforXML)
 $xmlWriter.WriteElementString('DESTINATION', "$selectedBackupDestination$backupMappedString")
 
 $xmlWriter.WriteEndElement()

--- a/robocopy-backup/robocopy-backup.ps1
+++ b/robocopy-backup/robocopy-backup.ps1
@@ -1,6 +1,6 @@
 <#
 .DESCRIPTION
-	ROBOCOPY-BACKUP Version: 1.2-ALPHA1
+	ROBOCOPY-BACKUP Version: 1.2-BETA1
 
 	This software is used for creating mirror copies/backups using Robocopy
 	This code is based on ntfs-hardlink-backup.ps1 from https://github.com/individual-it/ntfs-hardlink-backup
@@ -61,10 +61,11 @@
 	then be sure to specify a different ShadowCopySymLinkDir for each job.
 .PARAMETER SMTPPort
 	Port of the SMTP Server. Default=587
-.PARAMETER emailJobName
-	This is added in to the auto-generated email subject "Robocopy mirror of: hostname emailJobName by: username"
+.PARAMETER jobName
+	This is added in to the auto-generated email subject "Robocopy mirror of: hostname jobName by: username" and used in the status file.
+	Using the 'emailJobName' parameter is deprecated
 .PARAMETER emailSubject
-	Subject for the notification Email. This overrides the auto-generated email subject and emailJobName.
+	Subject for the notification Email. This overrides the auto-generated email subject and jobName.
 .PARAMETER emailSendRetries
 	How many times should we try to resend the Email. Default = 100
 .PARAMETER msToPauseBetweenEmailSendRetries
@@ -72,6 +73,9 @@
 .PARAMETER LogFile
 	Path and filename for the logfile. If just a path is given, then "yyyy-mm-dd hh-mm-ss.log" is written to that folder.
 	Default is to write "yyyy-mm-dd hh-mm-ss.log" in the backup destination folder.
+.PARAMETER statusFile
+	Path and filename for the status File. If just a path is given, then "status.xml" is written to that folder.
+	Default is to write "status.xml" in the logfile destination folder.
 .PARAMETER StepTiming
 	Switch on display of the time at each step of the job.
 .PARAMETER preExecutionCommand
@@ -139,9 +143,13 @@ Param(
 	[Parameter(Mandatory=$False)]
 	[string]$emailSubject="",
 	[Parameter(Mandatory=$False)]
+	[string]$jobName="",
+	[Parameter(Mandatory=$False)]
 	[string]$emailJobName="",
 	[Parameter(Mandatory=$False)]
 	[string]$LogFile="",
+	[Parameter(Mandatory=$False)]
+	[string]$statusFile="",
 	[Parameter(Mandatory=$False)]
 	[switch]$StepTiming=$False,
 	[Parameter(Mandatory=$False)]
@@ -706,6 +714,21 @@ if ([string]::IsNullOrEmpty($emailSubject)) {
 
 if ([string]::IsNullOrEmpty($emailJobName)) {
 	$emailJobName = Get-IniParameter "emailJobName" "${FQDN}"
+	
+	$output = "`WARNING: using the 'emailJobName' parameter is deprecated! Please use 'jobName'`n"
+	echo $output
+	$emailBody = "$emailBody`r`n$output`r`n"
+
+	$tempLogContent += $output	
+}
+
+if ([string]::IsNullOrEmpty($jobName)) {
+	$jobName = Get-IniParameter "jobName" "${FQDN}"
+	
+	#if there is still not $jobName set use the deprecated $emailJobName
+	if ([string]::IsNullOrEmpty($jobName)) {
+		$jobName=$emailJobName
+	}
 }
 
 if (-not $StepTiming.IsPresent) {
@@ -714,6 +737,9 @@ if (-not $StepTiming.IsPresent) {
 }
 
 if ([string]::IsNullOrEmpty($emailSubject)) {
+	
+	$emailJobName = $jobName #to use here the old name makes sense because this is only for Email
+	
 	if (-not ([string]::IsNullOrEmpty($emailJobName))) {
 		$emailJobName += " "
 	}
@@ -937,6 +963,24 @@ catch
 #write the logs from the time we hadn't a logfile into the file
 if ($LogFile) {
 	$tempLogContent | Out-File "$LogFile"  -encoding ASCII -append
+}
+
+if ([string]::IsNullOrEmpty($statusFile)) {
+	$statusFile = Get-IniParameter "statusFile" "${FQDN}"
+}
+
+if ([string]::IsNullOrEmpty($statusFile)) {
+	#no status File is specified, use the LogFile Folder as folder and "status.xml" as filename
+	$statusFile = "$logFileDestination\status.xml"
+} else {
+	if (-not [System.IO.Path]::IsPathRooted($statusFile)) {
+		#not a full path is given, so use the logfile Folder as basis
+		$statusFile = "$logFileDestination\$statusFile"
+	}
+	if (Test-Path -Path $statusFile -pathType container) {
+		# The status file parameter points to a folder, so create a "status.xml" in that folder.
+		$statusFile = "$statusFile\status.xml"
+	} 
 }
 
 if ([string]::IsNullOrEmpty($backupSources)) {
@@ -1451,6 +1495,33 @@ if (($parameters_ok -eq $True) -and ($doBackup -eq $True) -and (test-path $backu
 		$output | Out-File "$LogFile" -encoding ASCII -append
 	}
 }
+
+#XML Status report
+echo "============Generating XML Status report============"
+$xmlWriter = New-Object System.XMl.XmlTextWriter($statusFile,$Null)
+$xmlWriter.Formatting = 'Indented'
+$xmlWriter.Indentation = 1
+$xmlWriter.IndentChar = "`t"
+
+$xmlWriter.WriteStartDocument()
+
+if ($error_during_backup) {
+	$backupStatus = "ERROR"
+} else {
+	$backupStatus = "OK"
+}
+
+$xmlWriter.WriteStartElement('ROBOCOPY-BACKUP')
+$xmlWriter.WriteElementString('VERSION', $versionString)
+$xmlWriter.WriteElementString('STATUS', $backupStatus)
+$xmlWriter.WriteElementString('JOBNAME', $jobName)
+$xmlWriter.WriteElementString('LASTRUN', $dateTime)
+$xmlWriter.WriteElementString('DESTINATION', "$selectedBackupDestination$backupMappedString")
+
+$xmlWriter.WriteEndElement()
+$xmlWriter.WriteEndDocument()
+$xmlWriter.Flush()
+$xmlWriter.Close()
 
 if ($emailTo -AND $emailFrom -AND $SMTPServer) {
 	# Check if we can find any network adapter that has a default gateway

--- a/robocopy-backup/robocopy-to-remote-office.ini
+++ b/robocopy-backup/robocopy-to-remote-office.ini
@@ -3,6 +3,7 @@
 noShadowCopy=true
 logFilesToKeep=20
 Logfile=C:\Logs\robocopy-to-remote-office
+statusFile=robocopy-status.xml
 emailTo=ict.admin@mycompany.com
 emailFrom=backup@mycompany.com
 SMTPServer=mail.mycompany.com
@@ -14,9 +15,11 @@ emailSendRetries=50
 ; Make a robocopy mirror of the Admin, Finance and HR files on the Sydney server to the backup share in London
 backupDestination=\\london-dc-01\remoteofficebackup\sydney-dc-01
 backupSources=D:\Shares\Admin,D:\Shares\Finance,D:\Shares\HR
+jobName=Sydney-London-Mirror
 emailTo=ict.admin@au.mycompany.com
 [london-dc-01.mycompany.com]
 ; Make a robocopy mirror of the EU files on the London server to the backup share in Sydney
 backupDestination=\\sydney-dc-01\remoteofficebackup\london-dc-01
 backupSources=D:\Shares\EU
+jobName=London-Sydney-Mirror
 emailTo=ict.admin@uk.mycompany.com


### PR DESCRIPTION
and change the emailJobName parameter to jobName.
The user can specify the location and name of the status report file in
parameter statusFile. If not specified, it is written to status.xml in
the same folder as the log file.