### PR TITLE
Single copy should be mirror

### DIFF
--- a/ntfs-hardlink-backup/ntfs-hardlink-backup.ps1
+++ b/ntfs-hardlink-backup/ntfs-hardlink-backup.ps1
@@ -1261,7 +1261,7 @@ if (($parameters_ok -eq $True) -and ($doBackup -eq $True) -and (test-path $backu
 	{
 		# We don't want to have "\" at the end because we will quote the path later and ln.exe would
 		# treat this as escaping of the quote (\") and can not parse the command line.
-		# ln --copy "x:\" y:\dir\newdir
+		# ln --mirror "x:\" y:\dir\newdir
 		# see also https://github.com/individual-it/ntfs-hardlink-backup/issues/16
 		if ($backup_source.substring($backup_source.length-1,1) -eq "\") {
 			$backup_source=$backup_source.Substring(0,$backup_source.Length-1)
@@ -1547,12 +1547,12 @@ if (($parameters_ok -eq $True) -and ($doBackup -eq $True) -and (test-path $backu
 			$start_time = get-date -f "yyyy-MM-dd HH-mm-ss"
 
 			if ($lastBackupFolderName -eq "" ) {
-				echo "Full copy from $backup_source_path to $actualBackupDestination$backupMappedString"
+				echo "Mirror from $backup_source_path to $actualBackupDestination$backupMappedString"
 				if ($LogFile) {
-					"`r`nFull copy from $backup_source_path to $actualBackupDestination$backupMappedString" | Out-File "$LogFile"  -encoding ASCII -append
+					"`r`nMirror from $backup_source_path to $actualBackupDestination$backupMappedString" | Out-File "$LogFile"  -encoding ASCII -append
 				}
 
-				$lnArgs += "--copy"
+				$lnArgs += "--mirror"
 				$lnArgs += $backup_source_path
 				$lnArgs += $actualBackupDestination
 			} else {


### PR DESCRIPTION
When using "--copy" files accumulate - old files that have been deleted
in the source never get deleted from the destination.
Using "--mirror", the files in destination end up being exactly the same
as those in the source - new files are copied to, changed files are
overwritten in, deleted files are removed from the destination.