### PR TITLE
force TLS 1.2

### DIFF
--- a/ntfs-hardlink-backup/ntfs-hardlink-backup.ps1
+++ b/ntfs-hardlink-backup/ntfs-hardlink-backup.ps1
@@ -1859,6 +1859,7 @@ if ($emailTo -AND $emailFrom -AND $SMTPServer) {
 
 	if ($defaultGatewayExists) {
 		echo "============Sending Email============"
+		[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 		$stepCounter = 1
 
 		if ($LogFile) {


### PR DESCRIPTION
This will force Powershell to use TLSv1.2 which is the latest version.